### PR TITLE
Add Nourish tags for foods

### DIFF
--- a/src/main/resources/data/nourish/carbohydrates.json
+++ b/src/main/resources/data/nourish/carbohydrates.json
@@ -1,0 +1,18 @@
+{
+	"values": [
+		"chestcavity:raw_organ_meat",
+		"chestcavity:cooked_organ_meat",
+		"chestcavity:raw_rich_sausage",
+		"chestcavity:rich_sausage",
+		"chestcavity:raw_rich_mini_sausage",
+		"chestcavity:rich_mini_sausage",
+		"chestcavity:raw_toxic_organ_meat",
+		"chestcavity:cooked_toxic_organ_meat",
+		"chestcavity:raw_rich_toxic_sausage",
+		"chestcavity:rich_toxic_sausage",
+		"chestcavity:raw_human_organ_meat",
+		"chestcavity:cooked_human_organ_meat",
+		"chestcavity:raw_rich_human_sausage",
+		"chestcavity:rich_human_sausage"
+	]
+}

--- a/src/main/resources/data/nourish/fats.json
+++ b/src/main/resources/data/nourish/fats.json
@@ -1,0 +1,18 @@
+{
+	"values": [
+		"chestcavity:raw_organ_meat",
+		"chestcavity:cooked_organ_meat",
+		"chestcavity:raw_rich_sausage",
+		"chestcavity:rich_sausage",
+		"chestcavity:raw_rich_mini_sausage",
+		"chestcavity:rich_mini_sausage",
+		"chestcavity:raw_toxic_organ_meat",
+		"chestcavity:cooked_toxic_organ_meat",
+		"chestcavity:raw_rich_toxic_sausage",
+		"chestcavity:rich_toxic_sausage",
+		"chestcavity:raw_human_organ_meat",
+		"chestcavity:cooked_human_organ_meat",
+		"chestcavity:raw_rich_human_sausage",
+		"chestcavity:rich_human_sausage"
+	]
+}

--- a/src/main/resources/data/nourish/fruit.json
+++ b/src/main/resources/data/nourish/fruit.json
@@ -1,0 +1,18 @@
+{
+	"values": [
+		"chestcavity:raw_organ_meat",
+		"chestcavity:cooked_organ_meat",
+		"chestcavity:raw_rich_sausage",
+		"chestcavity:rich_sausage",
+		"chestcavity:raw_rich_mini_sausage",
+		"chestcavity:rich_mini_sausage",
+		"chestcavity:raw_toxic_organ_meat",
+		"chestcavity:cooked_toxic_organ_meat",
+		"chestcavity:raw_rich_toxic_sausage",
+		"chestcavity:rich_toxic_sausage",
+		"chestcavity:raw_human_organ_meat",
+		"chestcavity:cooked_human_organ_meat",
+		"chestcavity:raw_rich_human_sausage",
+		"chestcavity:rich_human_sausage"
+	]
+}

--- a/src/main/resources/data/nourish/protein.json
+++ b/src/main/resources/data/nourish/protein.json
@@ -1,0 +1,31 @@
+{
+	"values": [
+		"chestcavity:burnt_meat_chunk",
+		"chestcavity:raw_organ_meat",
+		"chestcavity:cooked_organ_meat",
+		"chestcavity:raw_butchered_meat",
+		"chestcavity:cooked_butchered_meat",
+		"chestcavity:raw_sausage",
+		"chestcavity:sausage",
+		"chestcavity:raw_rich_sausage",
+		"chestcavity:rich_sausage",
+		"chestcavity:raw_mini_sausage",
+		"chestcavity:mini_sausage",
+		"chestcavity:raw_rich_mini_sausage",
+		"chestcavity:rich_mini_sausage",
+		"chestcavity:raw_toxic_organ_meat",
+		"chestcavity:cooked_toxic_organ_meat",
+		"chestcavity:raw_toxic_sausage",
+		"chestcavity:toxic_sausage",
+		"chestcavity:raw_rich_toxic_sausage",
+		"chestcavity:rich_toxic_sausage",
+		"chestcavity:raw_human_organ_meat",
+		"chestcavity:cooked_human_organ_meat",
+		"chestcavity:raw_man_meat",
+		"chestcavity:cooked_man_meat",
+		"chestcavity:raw_human_sausage",
+		"chestcavity:human_sausage",
+		"chestcavity:raw_rich_human_sausage",
+		"chestcavity:rich_human_sausage"
+	]
+}

--- a/src/main/resources/data/nourish/vegetables.json
+++ b/src/main/resources/data/nourish/vegetables.json
@@ -1,0 +1,18 @@
+{
+	"values": [
+		"chestcavity:raw_organ_meat",
+		"chestcavity:cooked_organ_meat",
+		"chestcavity:raw_rich_sausage",
+		"chestcavity:rich_sausage",
+		"chestcavity:raw_rich_mini_sausage",
+		"chestcavity:rich_mini_sausage",
+		"chestcavity:raw_toxic_organ_meat",
+		"chestcavity:cooked_toxic_organ_meat",
+		"chestcavity:raw_rich_toxic_sausage",
+		"chestcavity:rich_toxic_sausage",
+		"chestcavity:raw_human_organ_meat",
+		"chestcavity:cooked_human_organ_meat",
+		"chestcavity:raw_rich_human_sausage",
+		"chestcavity:rich_human_sausage"
+	]
+}


### PR DESCRIPTION
The Nourish mod author suggested that I contribute in this manner. I listed all the various organ meats under all the different nutrients because that's how carnivorous animals get the nutrients they need. I sure hope I haven't forgotten anything, I was just copying from Emily's example.