### PR TITLE
rebalance saltwater

### DIFF
--- a/src/main/resources/data/chestcavity/organs/other/heart_saltwater.json
+++ b/src/main/resources/data/chestcavity/organs/other/heart_saltwater.json
@@ -3,7 +3,7 @@
   "organScores": [
     {"id":"chestcavity:health","value": "1"},
     {"id":"chestcavity:water_breath","value": ".5"},
-    {"id":"chestcavity:fire_resistant","value": "-1"}
+    {"id":"chestcavity:fire_resistant","value": "-.5"}
 
   ]
 }

--- a/src/main/resources/data/chestcavity/organs/other/lung_saltwater.json
+++ b/src/main/resources/data/chestcavity/organs/other/lung_saltwater.json
@@ -5,6 +5,6 @@
     {"id":"chestcavity:breath_capacity","value": "1"},
     {"id":"chestcavity:endurance","value": "1"},
     {"id":"chestcavity:water_breath","value": ".5"},
-    {"id":"chestcavity:fire_resistant","value": "-1"}
+    {"id":"chestcavity:fire_resistant","value": "-.5"}
   ]
 }


### PR DESCRIPTION
they now have a total score of 1, as water breath and fire resistant have the same value and in gameplay near double fire damage is far too much for water breath