### PR TITLE
Fix shearing sheep crashing server

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/util/OrganUtil.java
+++ b/src/main/java/net/tigereye/chestcavity/util/OrganUtil.java
@@ -1,5 +1,7 @@
 package net.tigereye.chestcavity.util;
 
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.client.MinecraftClient;
@@ -87,6 +89,7 @@ public class OrganUtil {
         });
     }
 
+    @Environment(EnvType.CLIENT)
     public static void displayCompatibility(ItemStack itemStack, World world, List<Text> tooltip, TooltipContext tooltipContext) {
 
         NbtCompound tag = itemStack.getNbt();


### PR DESCRIPTION
fixes #98 

Shearing sheep crashes the server, as described in #98. The bug was OrganUtil was loading MinecraftClient even on the server, which causes a ClassNotFoundException on the server.

I just limited this function to the client, as it appears to only be used in there. This fix worked for my server at least.