### PR TITLE
A few bugfixes

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/listeners/OrganAddStatusEffectListeners.java
+++ b/src/main/java/net/tigereye/chestcavity/listeners/OrganAddStatusEffectListeners.java
@@ -14,16 +14,18 @@ public class OrganAddStatusEffectListeners {
     public static void register(){
         OrganAddStatusEffectCallback.EVENT.register(OrganAddStatusEffectListeners::ApplyBuffPurging);
         OrganAddStatusEffectCallback.EVENT.register(OrganAddStatusEffectListeners::ApplyDetoxification);
+        OrganAddStatusEffectCallback.EVENT.register(OrganAddStatusEffectListeners::ApplyFiltration);
         OrganAddStatusEffectCallback.EVENT.register(OrganAddStatusEffectListeners::ApplyWithered);
     }
 
     private static StatusEffectInstance ApplyBuffPurging(LivingEntity entity, ChestCavityInstance cc, StatusEffectInstance instance) {
-        if(cc.getOrganScore(CCOrganScores.BUFF_PURGING) > 0
+        float buffPurgingDiff = cc.getOrganScore(CCOrganScores.BUFF_PURGING) - cc.getChestCavityType().getDefaultOrganScore(CCOrganScores.BUFF_PURGING);
+        if(buffPurgingDiff > 0
                 && ((CCStatusEffect)(instance.getEffectType())).CC_IsBeneficial())
         {
             CCStatusEffectInstance ccInstance = (CCStatusEffectInstance) instance;
             ccInstance.CC_setDuration((int)(instance.getDuration()/
-                    (1+(ChestCavity.config.BUFF_PURGING_DURATION_FACTOR*cc.getOrganScore(CCOrganScores.BUFF_PURGING)))));
+                    (1+(ChestCavity.config.BUFF_PURGING_DURATION_FACTOR*buffPurgingDiff))));
         }
         return instance;
     }
@@ -50,18 +52,19 @@ public class OrganAddStatusEffectListeners {
         {
             CCStatusEffectInstance ccInstance = (CCStatusEffectInstance) instance;
             ccInstance.CC_setDuration((int)(instance.getDuration()/
-                    (1+(ChestCavity.config.FILTRATION_DURATION_FACTOR*cc.getOrganScore(CCOrganScores.FILTRATION)))));
+                    (1+(ChestCavity.config.FILTRATION_DURATION_FACTOR*filtrationDiff))));
         }
         return instance;
     }
 
     private static StatusEffectInstance ApplyWithered(LivingEntity entity, ChestCavityInstance cc, StatusEffectInstance instance) {
-        if(cc.getOrganScore(CCOrganScores.WITHERED) > 0
+        float witheredDiff = cc.getOrganScore(CCOrganScores.WITHERED) - cc.getChestCavityType().getDefaultOrganScore(CCOrganScores.WITHERED);
+        if(witheredDiff > 0
                 && instance.getEffectType() == StatusEffects.WITHER)
         {
             CCStatusEffectInstance ccInstance = (CCStatusEffectInstance) instance;
             ccInstance.CC_setDuration((int)(instance.getDuration()/
-                    (1+(ChestCavity.config.WITHERED_DURATION_FACTOR*cc.getOrganScore(CCOrganScores.WITHERED)))));
+                    (1+(ChestCavity.config.WITHERED_DURATION_FACTOR*witheredDiff))));
         }
         return instance;
     }

--- a/src/main/java/net/tigereye/chestcavity/listeners/OrganTickListeners.java
+++ b/src/main/java/net/tigereye/chestcavity/listeners/OrganTickListeners.java
@@ -62,7 +62,7 @@ public class OrganTickListeners {
                 }
             }
         }
-        if(crystalsynthesis != 0 && entity.world.getTime() % ChestCavity.config.CRYSTALSYNTHESIS_FREQUENCY == 0 && !(entity instanceof EnderDragonEntity))
+        if(crystalsynthesis > 0 && entity.world.getTime() % ChestCavity.config.CRYSTALSYNTHESIS_FREQUENCY == 0 && !(entity instanceof EnderDragonEntity))
         {
             EndCrystalEntity oldcrystal = cc.connectedCrystal;
             //attempt to bind to a crystal

--- a/src/main/java/net/tigereye/chestcavity/registration/CCItems.java
+++ b/src/main/java/net/tigereye/chestcavity/registration/CCItems.java
@@ -13,6 +13,7 @@ public class CCItems {
 
 	public static final Item.Settings CHEST_OPENER_SETTINGS = new Item.Settings().maxCount(1).group(ItemGroup.TOOLS);
 	public static final Item.Settings FOOD_ITEM_SETTINGS = new Item.Settings().maxCount(64).group(ItemGroup.FOOD);
+	public static final Item.Settings INVISIBLE_FOOD_SETTINGS = new Item.Settings().maxCount(64);
 
 	public static final Item CHEST_OPENER = new ChestOpener();
 	public static final SwordItem WOODEN_CLEAVER = new SwordItem(ToolMaterials.WOOD,6,-3.2f,new Item.Settings().group(ItemGroup.COMBAT));
@@ -215,8 +216,8 @@ public class CCItems {
 	public static final Item RAW_RICH_DRAGON_SAUSAGE = new Item(FOOD_ITEM_SETTINGS.food(CCFoodComponents.RAW_RICH_DRAGON_SAUSAGE_FOOD_COMPONENT));
 	public static final Item COOKED_RICH_DRAGON_SAUSAGE = new Item(FOOD_ITEM_SETTINGS.food(CCFoodComponents.COOKED_RICH_DRAGON_SAUSAGE_FOOD_COMPONENT));
 
-	public static final Item CUD = new Item(FOOD_ITEM_SETTINGS.food(CCFoodComponents.CUD_FOOD_COMPONENT));
-	public static final Item FURNACE_POWER = new Item(FOOD_ITEM_SETTINGS.food(CCFoodComponents.FURNACE_POWER_FOOD_COMPONENT));
+	public static final Item CUD = new Item(INVISIBLE_FOOD_SETTINGS.food(CCFoodComponents.CUD_FOOD_COMPONENT));
+	public static final Item FURNACE_POWER = new Item(INVISIBLE_FOOD_SETTINGS.food(CCFoodComponents.FURNACE_POWER_FOOD_COMPONENT));
 
 	public static void register() {
 		registerItem("chest_opener", CHEST_OPENER);

--- a/src/main/java/net/tigereye/chestcavity/util/ChestCavityUtil.java
+++ b/src/main/java/net/tigereye/chestcavity/util/ChestCavityUtil.java
@@ -279,7 +279,7 @@ public class ChestCavityUtil {
 
     public static boolean attemptArrowDodging(ChestCavityInstance cc, DamageSource source){
         float dodge = cc.getOrganScore(CCOrganScores.ARROW_DODGING);
-        if(dodge == 0){
+        if(dodge <= 0){
             return false;
         }
         if(cc.owner.hasStatusEffect(CCStatusEffects.ARROW_DODGE_COOLDOWN)){
@@ -288,9 +288,7 @@ public class ChestCavityUtil {
         if (!(source instanceof ProjectileDamageSource)) {
             return false;
         }
-        if(!OrganUtil.teleportRandomly(cc.owner,ChestCavity.config.ARROW_DODGE_DISTANCE/dodge)){
-            return false;
-        }
+        OrganUtil.teleportRandomly(cc.owner,ChestCavity.config.ARROW_DODGE_DISTANCE/dodge);
         cc.owner.addStatusEffect(new StatusEffectInstance(CCStatusEffects.ARROW_DODGE_COOLDOWN, (int) (ChestCavity.config.ARROW_DODGE_COOLDOWN/dodge), 0, false, false, true));
         return true;
     }

--- a/src/main/java/net/tigereye/chestcavity/util/OrganUtil.java
+++ b/src/main/java/net/tigereye/chestcavity/util/OrganUtil.java
@@ -81,7 +81,7 @@ public class OrganUtil {
                 } else if (score >= -.75f) {
                     tier = "quality.chestcavity.greatly_reduces";
                 } else {
-                    tier = "quality.chestcavity.greatly_reduces";
+                    tier = "quality.chestcavity.cripples";
                 }
             }
             Text text = Text.translatable("organscore." + organ.getNamespace() + "." + organ.getPath(), Text.translatable(tier));


### PR DESCRIPTION
Fixes bug where "Cripples" is never displayed
Partially addresses #105, allowing filtration to function properly, but does NOT fix the consumption-only issue
Removes item group from cud and furnace powered items
Fixes arrow dodging and crystalsynthesis to do nothing when negative
Arrow dodging now still grants immunity if the teleportation fails